### PR TITLE
Replace Tkinter GUI with HTTP WebApp serving local images and add tests

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,15 +1,7 @@
-import name
 import image
 import gui
 
 if __name__ == '__main__':
-    namegen = name.NameGenerator()
-    names = namegen.names
-
     imgen = image.ImageGenerator()
-    images = imgen.images
-    urls = imgen.urls
-
-    win = gui.Window(names=names, images=images, urls=urls)
-    win.run()
-
+    app = gui.WebApp(images=imgen.images)
+    app.run()

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -1,0 +1,21 @@
+import unittest
+from unittest.mock import patch
+
+import gui
+
+
+class WebAppTests(unittest.TestCase):
+    def test_get_image_name_skips_previous_when_possible(self):
+        app = gui.WebApp(images=['/tmp/a.jpg', '/tmp/b.jpg'])
+        with patch('random.choice', side_effect=lambda seq: seq[0]):
+            result = app.get_image_name(previous_image='a.jpg')
+        self.assertEqual(result, 'b.jpg')
+
+    def test_resolve_image_path_blocks_path_traversal(self):
+        app = gui.WebApp(images=[])
+        blocked = app.resolve_image_path('../etc/passwd')
+        self.assertIsNone(blocked)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### Motivation

- Replace the desktop Tkinter-based interface with a lightweight HTTP server so the app can be accessed via a browser and serve local image files. 
- Improve security by preventing remote image fetching and blocking path traversal when resolving images. 

### Description

- Remove the Tkinter `Window` implementation and introduce `WebApp` which starts a `ThreadingHTTPServer` and serves an HTML UI. 
- Serve images from an `images/` directory with safe resolution via `resolve_image_path` that blocks path traversal and returns proper MIME types. 
- Implement request handlers for `GET`, `POST`, and `HEAD` in `make_handler`, include a minimal HTML template with a form to request another random image, and avoid logging in the handler. 
- Update `main.py` to instantiate `WebApp` (feeding it `image.ImageGenerator().images`) and start the server, and remove the previous name/URL fetching logic. 

### Testing

- Added `tests/test_gui.py` with unit tests for `get_image_name` behavior and `resolve_image_path` path-traversal protection. 
- Ran the test suite with `python -m unittest -q` and the new tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0a4db7750833186241e1567fc5516)